### PR TITLE
Add quick wifi connect using saved AP parameters

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -72,3 +72,4 @@ The following binary downloads have been compiled with ESP8266/Arduino library c
 - Add support for up to four MQTT GroupTopics using the same optional Device Group names (#8014)
 - Add console command history (#7483, #8015)
 - Add support for longer template names
+- Add quick wifi connect using saved AP parameters when ``SetOption56 0`` (#3189)

--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add command ``Sensor10 0/1/2`` to control BH1750 resolution - 0 = High (default), 1 = High2, 2 = Low (#8016)
 - Add command ``Sensor10 31..254`` to control BH1750 measurement time which defaults to 69 (#8016)
 - Add command ``SetOption91 1`` to enable fading at startup / power on
+- Add quick wifi connect using saved AP parameters when ``SetOption56 0`` (#3189)
 
 ### 8.2.0.2 20200328
 

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -470,8 +470,10 @@ struct SYSCFG {
   uint8_t       bri_preset_low;            // F06
   uint8_t       bri_preset_high;           // F07
   int8_t        hum_comp;                  // F08
+  uint8_t       channel;                   // F09
+  uint8_t       bssid[6];                  // F0A
 
-  uint8_t       free_f09[175];             // F09
+  uint8_t       free_f10[168];             // F10
 
   uint16_t      pulse_counter_debounce_low;  // FB8
   uint16_t      pulse_counter_debounce_high; // FBA


### PR DESCRIPTION
Add quick wifi connect using saved AP parameters when ``SetOption56 0`` (#3189)

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ ] The pull request is done against the latest dev branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core Tasmota_core_stage
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
