### PR TITLE
Fix homekit compile with IDF4

### DIFF
--- a/lib/libesp32_div/ESP32-HomeKit/src/port/bignum.c
+++ b/lib/libesp32_div/ESP32-HomeKit/src/port/bignum.c
@@ -21,7 +21,14 @@
  *
  */
 
-//#include "soc/hwcrypto_periph.h"
+#if __has_include("esp_idf_version.h")
+#include "esp_idf_version.h"
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
+#warning("IDF is 4 or later")
+#include "soc/hwcrypto_periph.h"
+#endif
+#endif
+
 #include "soc/hwcrypto_reg.h"
 #include "driver/periph_ctrl.h"
 #include <mbedtls/bignum.h>

--- a/lib/libesp32_div/ESP32-HomeKit/src/port/esp_bignum.c
+++ b/lib/libesp32_div/ESP32-HomeKit/src/port/esp_bignum.c
@@ -20,6 +20,14 @@
  *  limitations under the License.
  *
  */
+#if __has_include("esp_idf_version.h")
+#include "esp_idf_version.h"
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
+#warning("IDF is 4 or later")
+#include "soc/hwcrypto_periph.h"
+#endif
+#endif
+
 #include <stdio.h>
 #include <string.h>
 #include <malloc.h>
@@ -27,7 +35,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <sys/param.h>
-//#include "soc/hwcrypto_periph.h"
 #include "esp_system.h"
 #include "esp_log.h"
 #include "esp_attr.h"


### PR DESCRIPTION
* Fix compile error for IDF -> missing include file
