### PR TITLE
Enable exceptions for bluetooth

### DIFF
--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -69,7 +69,8 @@ lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_i2c, lib/lib_rf, 
 
 [env:tasmota32-bluetooth]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DFIRMWARE_BLUETOOTH
+build_flags             = ${common32.build_flags} -fexceptions -DFIRMWARE_BLUETOOTH
+build_unflags           = ${common32.build_unflags} -fno-exceptions
 lib_extra_dirs          = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_ssl
 
 [env:tasmota32-display]


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ ] The pull request is done against the latest development branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
