### PR TITLE
use Bluetooth firmware for Homekit

### DIFF
--- a/tasmota/tasmota_configurations.h
+++ b/tasmota/tasmota_configurations.h
@@ -1049,8 +1049,4 @@
   #define USE_TLS                              // flag indicates we need to include TLS code
 #endif                                         // USE_MQTT_TLS
 
-#if(USE_MI_HOMEKIT != 1)                       // Enable(1)/ Disable(0) Homekit, only for the .c-file
-  #undef USE_MI_HOMEKIT
-#endif //USE_MI_HOMEKIT
-
 #endif  // _TASMOTA_CONFIGURATIONS_H_

--- a/tasmota/tasmota_configurations_ESP32.h
+++ b/tasmota/tasmota_configurations_ESP32.h
@@ -56,109 +56,6 @@
 #endif  // FIRMWARE_WEBCAM
 
 /*********************************************************************************************\
- * [tasmota32-odroidgo.bin]
- * Provide an image with useful supported sensors enabled for Odroid Go
-\*********************************************************************************************/
-
-#ifdef FIRMWARE_ODROID_GO
-
-#undef CODE_IMAGE_STR
-#define CODE_IMAGE_STR "odroid-go"
-
-#undef MODULE
-#define MODULE                 ODROID_GO         // [Module] Select default module from tasmota_template.h
-#undef FALLBACK_MODULE
-#define FALLBACK_MODULE        ODROID_GO         // [Module2] Select default module on fast reboot where USER_MODULE is user template
-
-#define USE_ODROID_GO                            // Add support for Odroid Go
-#define USE_SDCARD
-
-#define USE_WEBCLIENT_HTTPS
-
-#undef USE_HOME_ASSISTANT
-
-#define USE_I2C
-#define USE_SPI
-  #define USE_DISPLAY
-  #define SHOW_SPLASH
-#ifdef USE_UNIVERSAL_DISPLAY
-  #define USE_LVGL
-  #define USE_LVGL_FREETYPE
-//  #define USE_DISPLAY_LVGL_ONLY
-#else
-  #define USE_DISPLAY_ILI9341                      // [DisplayModel 4] Enable ILI9341 Tft 480x320 display (+19k code)
-  #define USE_DISPLAY_MODES1TO5
-#endif
-//#define USE_BLE_ESP32                            // Enable new BLE driver
-//#define USE_MI_ESP32                             // (ESP32 only) Add support for ESP32 as a BLE-bridge (+9k2 mem, +292k flash)
-#endif  // FIRMWARE_ODROID_GO
-
-/*********************************************************************************************\
- * [tasmota32-core2.bin]
- * Provide an image with useful supported sensors enabled for M5stack core2
-\*********************************************************************************************/
-
-#ifdef FIRMWARE_M5STACK_CORE2
-
-#undef CODE_IMAGE_STR
-#define CODE_IMAGE_STR "core2"
-
-#undef MODULE
-#define MODULE                 M5STACK_CORE2     // [Module] Select default module from tasmota_template.h
-#undef FALLBACK_MODULE
-#define FALLBACK_MODULE        M5STACK_CORE2     // [Module2] Select default module on fast reboot where USER_MODULE is user template
-
-#undef USE_HOME_ASSISTANT
-
-#define USE_M5STACK_CORE2                        // Add support for M5Stack Core2
-  #define USE_I2S_SAY_TIME
-  #define USE_I2S_WEBRADIO
-#define USE_SDCARD
-
-#define USE_WEBCLIENT_HTTPS
-
-#define USE_I2C
-  #define USE_BMA423
-  #define USE_MPU_ACCEL
-#define USE_SPI
-  #define USE_DISPLAY
-  #define SHOW_SPLASH
-#ifdef USE_UNIVERSAL_DISPLAY
-  #define USE_LVGL
-  #define USE_LVGL_FREETYPE
-//  #define USE_DISPLAY_LVGL_ONLY
-#else
-  #define USE_DISPLAY_ILI9341                  // [DisplayModel 4] Enable ILI9341 Tft 480x320 display (+19k code)
-  #define USE_DISPLAY_MODES1TO5
-#endif
-    #define USE_TOUCH_BUTTONS
-    #define JPEG_PICTS
-    #define USE_FT5206
-
-#define USE_SENDMAIL
-#define USE_ESP32MAIL
-
-#ifndef USE_RULES
-  #define USE_SCRIPT                             // Add support for script (+17k code)
-// Script related defines
-  #define MAXVARS 75
-  #define MAXSVARS 15
-  #define MAXFILT 10
-  #define UFSYS_SIZE 8192
-  #define USE_SCRIPT_TASK
-  #define LARGE_ARRAYS
-  #define SCRIPT_LARGE_VNBUFF
-  #define USE_SCRIPT_GLOBVARS
-  #define USE_SCRIPT_SUB_COMMAND
-  #define USE_ANGLE_FUNC
-  #define USE_SCRIPT_WEB_DISPLAY
-  #define SCRIPT_FULL_WEBPAGE
-  #define SCRIPT_GET_HTTPS_JP
-  #define USE_GOOGLE_CHARTS
-#endif  // USE_RULES
-#endif  // FIRMWARE_M5STACK_CORE2
-
-/*********************************************************************************************\
  * [tasmota32-bluetooth.bin]
  * Provide an image with BLE support
 \*********************************************************************************************/
@@ -181,10 +78,16 @@
 
 #define USE_ADC
 //#undef USE_BERRY                                 // Disable Berry scripting language
-#define USE_BLE_ESP32                            // Enable new BLE driver
-#define USE_EQ3_ESP32
-#define USE_MI_ESP32                             // (ESP32 only) Add support for ESP32 as a BLE-bridge (+9k2 mem, +292k flash)
-#define USE_MI_EXT_GUI                         //enable dashboard style GUI
+#if defined(USE_MI_HOMEKIT)                      // Switch between Homekit and full BLE driver
+  #define USE_MI_ESP32
+  #if(USE_MI_HOMEKIT != 1)                       // Enable(1)/ Disable(0) Homekit, only for the .c-file
+    #undef USE_MI_HOMEKIT
+  #endif // disable USE_MI_HOMEKIT
+#else
+  #define USE_BLE_ESP32                          // Enable full BLE driver
+  #define USE_EQ3_ESP32
+  #define USE_MI_ESP32                           // (ESP32 only) Add support for ESP32 as a BLE-bridge (+9k2 mem, +292k flash)
+#endif // enable USE_MI_HOMEKIT
 
 #endif  // FIRMWARE_BLUETOOTH
 
@@ -212,6 +115,8 @@
 #define USE_SPI
 #define USE_LVGL
 #define USE_LVGL_FREETYPE
+  #undef SET_ESP32_STACK_SIZE
+  #define SET_ESP32_STACK_SIZE (24 * 1024)
 #define USE_LVGL_PNG_DECODER
 #define USE_DISPLAY
 #define SHOW_SPLASH
@@ -224,7 +129,6 @@
 #define USE_DISPLAY_LVGL_ONLY
 
 #undef USE_DISPLAY_MODES1TO5
-#undef SHOW_SPLASH
 #undef USE_DISPLAY_LCD
 #undef USE_DISPLAY_SSD1306
 #undef USE_DISPLAY_MATRIX


### PR DESCRIPTION
use `-DUSE_MI_HOMEKIT` as switch to enable new BLE MI driver


## Checklist:
  - [ ] The pull request is done against the latest development branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
