### PR TITLE
Use esptool command "before_reset usb_reset"

### DIFF
--- a/boards/esp32c3cdc.json
+++ b/boards/esp32c3cdc.json
@@ -36,6 +36,7 @@
       "maximum_ram_size": 327680,
       "maximum_size": 4194304,
       "require_upload_port": true,
+      "before_reset": "usb_reset",
       "speed": 460800
     },
     "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/hw-reference/esp32c3/user-guide-devkitm-1.html",

--- a/boards/esp32s2cdc.json
+++ b/boards/esp32s2cdc.json
@@ -36,6 +36,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
+    "before_reset": "usb_reset",
     "speed": 460800
   },
   "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-saola-1-v1.2.html",

--- a/boards/esp32s3cdc-box.json
+++ b/boards/esp32s3cdc-box.json
@@ -31,6 +31,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 16777216,
     "require_upload_port": true,
+    "before_reset": "usb_reset",
     "speed": 460800
   },
   "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",

--- a/boards/esp32s3cdc.json
+++ b/boards/esp32s3cdc.json
@@ -38,6 +38,7 @@
     "maximum_ram_size": 327680,
     "maximum_size": 4194304,
     "require_upload_port": true,
+    "before_reset": "usb_reset",
     "speed": 460800
   },
   "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",


### PR DESCRIPTION
## Description:

for CDC devices to get them in flash boot mode. 

## Checklist:
  - [ ] The pull request is done against the latest development branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
