### PR TITLE
Add some checks for valid env

### DIFF
--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -160,8 +160,7 @@ def esp32_build_filesystem(fs_size):
     if not os.listdir(filesystem_dir):
         print("No files added -> will NOT create littlefs.bin and NOT overwrite fs partition!")
         return False
-    env.Replace( MKSPIFFSTOOL=platform.get_package_dir("tool-mklittlefs") + '/mklittlefs' )
-    tool = env.subst(env["MKSPIFFSTOOL"])
+    tool = env.subst(env["MKFSTOOL"])
     cmd = (tool,"-c",filesystem_dir,"-s",fs_size,join(env.subst("$BUILD_DIR"),"littlefs.bin"))
     returncode = subprocess.call(cmd, shell=False)
     # print(returncode)

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -136,13 +136,12 @@ def esp32_create_chip_string(chip):
         tasmota_platform += "cdc"
         print("WARNING: board definition uses CDC configuration, but environment name does not -> adding 'cdc' to environment name")
         print("Please correct your actual build environment, to avoid undefined behavior in build process!!")
-    if ("solo1" in tasmota_platform_org or "CORE32SOLO1" in extra_flags or "FRAMEWORK_ARDUINO_SOLO1" in build_flags) and "tasmota32solo1" not in tasmota_platform_org:
+    if ("CORE32SOLO1" in extra_flags or "FRAMEWORK_ARDUINO_SOLO1" in build_flags) and "tasmota32solo1" not in tasmota_platform_org:
         print("Unexpected naming convention in this build environment:", tasmota_platform_org)
         print("Expected build environment name like 'tasmota32solo1-whatever-you-want'")
-        tasmota_platform_org = tasmota_platform_org.replace("solo1", "").replace("32", "").replace("tasmota", "tasmota32solo1")
-        tasmota_platform = tasmota_platform_org.split('-')[0]
-        print("WARNING: Changed environment name to:", tasmota_platform_org.replace("-", ""))
+        #tasmota_platform_org = tasmota_platform_org.replace("solo1", "").replace("32", "").replace("tasmota", "tasmota32solo1")
         print("Please correct your actual build environment, to avoid undefined behavior in build process!!")
+        tasmota_platform = "tasmota32solo1"
     return tasmota_platform
 
 def esp32_build_filesystem(fs_size):

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -136,7 +136,7 @@ def esp32_create_chip_string(chip):
         tasmota_platform += "cdc"
         print("WARNING: board definition uses CDC configuration, but environment name does not -> adding 'cdc' to environment name")
         print("Please correct your actual build environment, to avoid undefined behavior in build process!!")
-    if "solo1" in tasmota_platform_org and "tasmota32solo1" not in tasmota_platform_org:
+    if ("solo1" in tasmota_platform_org or if "CORE32SOLO1" in extra_flags or "FRAMEWORK_ARDUINO_SOLO1" in build_flags) and "tasmota32solo1" not in tasmota_platform_org:
         print("Unexpected naming convention in this build environment:", tasmota_platform_org)
         print("Expected build environment name like 'tasmota32solo1-whatever-you-want'")
         tasmota_platform_org = tasmota_platform_org.replace("solo1", "").replace("32", "").replace("tasmota", "tasmota32solo1")

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -302,7 +302,7 @@ def esp32_create_combined_bin(source, target, env):
         try:
             #esptool.main(cmd)
             #output = subprocess.run(esptoolpy_cmd, capture_output=True).stdout.splitlines()
-            subprocess.call(esptool.main(cmd), shell=False)
+            output = subprocess.call(esptool.main(cmd), capture_output=True).stdout.splitlines()
         except:
             print("")
             print("")

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -302,7 +302,8 @@ def esp32_create_combined_bin(source, target, env):
         try:
             esptool.main(cmd)
         except:
-            print("\u001b[31;1m************ Generating the Tasmota factory image failed *************\u001b[31;1m")
+            print(
+                "\u001b[31;1m************ Generating the Tasmota factory image failed *************\u001b[31;1m")
             print("*   Probably unusual naming convention in this build environment     *")
             print("* Expected build environment name like 'tasmota32-whatever-you-want' *")
 

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -301,7 +301,7 @@ def esp32_create_combined_bin(source, target, env):
         #print('Using esptool.py arguments: %s' % ' '.join(cmd))
         try:
             #esptool.main(cmd)
-            output = subprocess.run(esptool.main(cmd), shell=False, capture_output=False)
+            output = subprocess.DEVNULL(esptool.main(cmd), shell=False)
         except:
             print()
             print()

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -140,8 +140,6 @@ def esp32_create_chip_string(chip):
         print("Unexpected naming convention in this build environment:", tasmota_platform_org)
         print("Expected build environment name like 'tasmota32solo1-whatever-you-want'")
         tasmota_platform_org = tasmota_platform_org.replace("solo1", "").replace("32", "").replace("tasmota", "tasmota32solo1")
-        #tasmota_platform_org = tasmota_platform_org.replace("32", "")
-        #tasmota_platform_org = tasmota_platform_org.replace("tasmota", "tasmota32solo1")
         tasmota_platform = tasmota_platform_org.split('-')[0]
         print("WARNING: Changed environment name to:", tasmota_platform_org.replace("-", ""))
         print("Please correct your actual build environment, to avoid undefined behavior in build process!!")

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -302,8 +302,9 @@ def esp32_create_combined_bin(source, target, env):
         try:
             esptool.main(cmd)
         except:
-            print(
-                "\u001b[31;1m************ Generating the Tasmota factory image failed *************\u001b[31;1m")
+            print("")
+            print("")
+            print("\u001b[31;1m************ Generating the Tasmota factory image failed *************\u001b[31;1m")
             print("*   Probably unusual naming convention in this build environment     *")
             print("* Expected build environment name like 'tasmota32-whatever-you-want' *")
 

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -143,7 +143,7 @@ def esp32_create_chip_string(chip):
         tasmota_platform_org = tasmota_platform_org.replace("32", "")
         tasmota_platform_org = tasmota_platform_org.replace("tasmota", "tasmota32solo1")
         tasmota_platform = tasmota_platform_org.split('-')[0]
-        print("WARNING: Changed environment name to:", tasmota_platform_org)
+        print("WARNING: Changed environment name to:", tasmota_platform_org.replace("-", ""))
         print("Please correct your actual build environment, to avoid undefined behavior in build process!!")
     return tasmota_platform
 

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -306,4 +306,5 @@ def esp32_create_combined_bin(source, target, env):
         #print('Using esptool.py arguments: %s' % ' '.join(cmd))
         esptool.main(cmd)
 
+
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", esp32_create_combined_bin)

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -136,7 +136,7 @@ def esp32_create_chip_string(chip):
         tasmota_platform += "cdc"
         print("WARNING: board definition uses CDC configuration, but environment name does not -> adding 'cdc' to environment name")
         print("Please correct your actual build environment, to avoid undefined behavior in build process!!")
-    if ("solo1" in tasmota_platform_org or if "CORE32SOLO1" in extra_flags or "FRAMEWORK_ARDUINO_SOLO1" in build_flags) and "tasmota32solo1" not in tasmota_platform_org:
+    if ("solo1" in tasmota_platform_org or "CORE32SOLO1" in extra_flags or "FRAMEWORK_ARDUINO_SOLO1" in build_flags) and "tasmota32solo1" not in tasmota_platform_org:
         print("Unexpected naming convention in this build environment:", tasmota_platform_org)
         print("Expected build environment name like 'tasmota32solo1-whatever-you-want'")
         tasmota_platform_org = tasmota_platform_org.replace("solo1", "").replace("32", "").replace("tasmota", "tasmota32solo1")

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -301,8 +301,7 @@ def esp32_create_combined_bin(source, target, env):
         #print('Using esptool.py arguments: %s' % ' '.join(cmd))
         try:
             #esptool.main(cmd)
-            #output = subprocess.run(esptoolpy_cmd, capture_output=True).stdout.splitlines()
-            output = subprocess.run(esptool.main(cmd), capture_output=True).stdout.splitlines()
+            output = subprocess.run(esptool.main(cmd), shell=False, capture_output=False)
         except:
             print()
             print()

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -299,7 +299,11 @@ def esp32_create_combined_bin(source, target, env):
 
     if("safeboot" not in firmware_name):
         #print('Using esptool.py arguments: %s' % ' '.join(cmd))
-        esptool.main(cmd)
-
+        try:
+            esptool.main(cmd)
+        except:
+            print("\u001b[31;1m************ Generating the Tasmota factory image failed *************\u001b[31;1m")
+            print("*   Probably unusual naming convention in this build environment     *")
+            print("* Expected build environment name like 'tasmota32-whatever-you-want' *")
 
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", esp32_create_combined_bin)

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -306,8 +306,8 @@ def esp32_create_combined_bin(source, target, env):
         except:
             print()
             print()
-            print("\033[31m************ Generating the Tasmota factory image failed *************")
-            print("\033[31m*   Probably unusual naming convention in this build environment     *")
-            print("\033[31m* Expected build environment name like 'tasmota32-whatever-you-want' *\033[0m")
+            print("\u001b[31m************ Generating the Tasmota factory image failed *************")
+            print("\u001b[31m*   Probably unusual naming convention in this build environment     *")
+            print("\u001b[31m* Expected build environment name like 'tasmota32-whatever-you-want' *\u001b[0m")
 
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", esp32_create_combined_bin)

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -129,7 +129,7 @@ def esp32_create_chip_string(chip):
     tasmota_platform_org = env.subst("$BUILD_DIR").split(os.path.sep)[-1]
     tasmota_platform = tasmota_platform_org.split('-')[0]
     if "tasmota" + chip[3:] not in tasmota_platform: # quick check for a valid name like 'tasmota' + '32c3'
-        print("Unexpected naming convention in this build environment: ", tasmota_platform_org)
+        print("Unexpected naming convention in this build environment:", tasmota_platform_org)
         print("Expected build environment name like 'tasmota32-whatever-you-want'")
         print("Please correct your actual build environment, to avoid undefined behavior in build process!!")
     if "-DUSE_USB_CDC_CONSOLE" in env.BoardConfig().get("build.extra_flags") and "cdc" not in tasmota_platform:
@@ -137,9 +137,11 @@ def esp32_create_chip_string(chip):
         print("WARNING: board definition uses CDC configuration, but environment name does not -> adding 'cdc' to environment name")
         print("Please correct your actual build environment, to avoid undefined behavior in build process!!")
     if "solo1" in tasmota_platform_org and "tasmota32solo1" not in tasmota_platform_org:
-        print("Unexpected naming convention in this build environment: ", tasmota_platform_org)
+        print("Unexpected naming convention in this build environment:", tasmota_platform_org)
         print("Expected build environment name like 'tasmota32solo1-whatever-you-want'")
-        tasmota_platform_org = tasmota_platform_org.replace("solo1", "tasmota32solo1")
+        tasmota_platform_org = tasmota_platform_org.replace("solo1", "")
+        tasmota_platform_org = tasmota_platform_org.replace("32", "")
+        tasmota_platform_org = tasmota_platform_org.replace("tasmota", "tasmota32solo1")
         tasmota_platform = tasmota_platform_org.split('-')[0]
         print("WARNING: Changed environment name to:", tasmota_platform_org)
         print("Please correct your actual build environment, to avoid undefined behavior in build process!!")

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -302,7 +302,7 @@ def esp32_create_combined_bin(source, target, env):
         try:
             #esptool.main(cmd)
             #output = subprocess.run(esptoolpy_cmd, capture_output=True).stdout.splitlines()
-            output = subprocess.call(esptool.main(cmd), capture_output=True).stdout.splitlines()
+            output = subprocess.run(esptool.main(cmd), capture_output=True).stdout.splitlines()
         except:
             print("")
             print("")

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -306,8 +306,8 @@ def esp32_create_combined_bin(source, target, env):
         except:
             print("")
             print("")
-            print("\u001b[31;1m************ Generating the Tasmota factory image failed *************\u001b[31;1m")
+            print("\u001b[31;1m************ Generating the Tasmota factory image failed *************")
             print("*   Probably unusual naming convention in this build environment     *")
-            print("* Expected build environment name like 'tasmota32-whatever-you-want' *")
+            print("* Expected build environment name like 'tasmota32-whatever-you-want' *\u001b[31;1m")
 
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", esp32_create_combined_bin)

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -303,14 +303,7 @@ def esp32_create_combined_bin(source, target, env):
             print("Will use custom upload command for flashing operation to add file system defined for this build target.")
 
     if("safeboot" not in firmware_name):
-        try:
-            print('Using esptool.py arguments: %s' % ' '.join(cmd))
-            esptool.main(cmd)
-        except:
-            print()
-            print()
-            print("\u001b[31m************ Generating the Tasmota factory image failed *************")
-            print("\u001b[31m*   Probably unusual naming convention in this build environment     *")
-            print("\u001b[31m* Expected build environment name like 'tasmota32-whatever-you-want' *\u001b[0m")
+        #print('Using esptool.py arguments: %s' % ' '.join(cmd))
+        esptool.main(cmd)
 
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", esp32_create_combined_bin)

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -129,18 +129,20 @@ def esp32_create_chip_string(chip):
     tasmota_platform_org = env.subst("$BUILD_DIR").split(os.path.sep)[-1]
     tasmota_platform = tasmota_platform_org.split('-')[0]
     if "tasmota" + chip[3:] not in tasmota_platform: # quick check for a valid name like 'tasmota' + '32c3'
-        print("Unexpected naming conventions in this build environment: ", tasmota_platform_org)
+        print("Unexpected naming convention in this build environment: ", tasmota_platform_org)
         print("Expected build environment name like 'tasmota32-whatever-you-want'")
-        print("Please correct your actual used environment, to avoid undefined behavior!!")
+        print("Please correct your actual build environment, to avoid undefined behavior in build process!!")
     if "-DUSE_USB_CDC_CONSOLE" in env.BoardConfig().get("build.extra_flags") and "cdc" not in tasmota_platform:
         tasmota_platform += "cdc"
         print("WARNING: board definition uses CDC configuration, but environment name does not -> adding 'cdc' to environment name")
-        print("Please correct your actual used environment, to avoid undefined behavior!!")
+        print("Please correct your actual build environment, to avoid undefined behavior in build process!!")
     if "solo1" in tasmota_platform_org and "tasmota32solo1" not in tasmota_platform_org:
-        print("Unexpected naming convention in this environment: ", tasmota_platform_org, " -> Undefined behavior for further build process!!")
+        print("Unexpected naming convention in this build environment: ", tasmota_platform_org)
         print("Expected build environment name like 'tasmota32solo1-whatever-you-want'")
-        print("WARNING: Changing environment name to:", tasmota_platform)
-
+        tasmota_platform_org = tasmota_platform_org.replace("solo1", "tasmota32solo1")
+        tasmota_platform = tasmota_platform_org.split('-')[0]
+        print("WARNING: Changed environment name to:", tasmota_platform_org)
+        print("Please correct your actual build environment, to avoid undefined behavior in build process!!")
     return tasmota_platform
 
 def esp32_build_filesystem(fs_size):

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -139,7 +139,6 @@ def esp32_create_chip_string(chip):
     if ("CORE32SOLO1" in extra_flags or "FRAMEWORK_ARDUINO_SOLO1" in build_flags) and "tasmota32solo1" not in tasmota_platform_org:
         print("Unexpected naming convention in this build environment:", tasmota_platform_org)
         print("Expected build environment name like 'tasmota32solo1-whatever-you-want'")
-        #tasmota_platform_org = tasmota_platform_org.replace("solo1", "").replace("32", "").replace("tasmota", "tasmota32solo1")
         print("Please correct your actual build environment, to avoid undefined behavior in build process!!")
         tasmota_platform = "tasmota32solo1"
     return tasmota_platform

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -139,9 +139,9 @@ def esp32_create_chip_string(chip):
     if "solo1" in tasmota_platform_org and "tasmota32solo1" not in tasmota_platform_org:
         print("Unexpected naming convention in this build environment:", tasmota_platform_org)
         print("Expected build environment name like 'tasmota32solo1-whatever-you-want'")
-        tasmota_platform_org = tasmota_platform_org.replace("solo1", "")
-        tasmota_platform_org = tasmota_platform_org.replace("32", "")
-        tasmota_platform_org = tasmota_platform_org.replace("tasmota", "tasmota32solo1")
+        tasmota_platform_org = tasmota_platform_org.replace("solo1", "").replace("32", "").replace("tasmota", "tasmota32solo1")
+        #tasmota_platform_org = tasmota_platform_org.replace("32", "")
+        #tasmota_platform_org = tasmota_platform_org.replace("tasmota", "tasmota32solo1")
         tasmota_platform = tasmota_platform_org.split('-')[0]
         print("WARNING: Changed environment name to:", tasmota_platform_org.replace("-", ""))
         print("Please correct your actual build environment, to avoid undefined behavior in build process!!")

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -298,10 +298,9 @@ def esp32_create_combined_bin(source, target, env):
             print("Will use custom upload command for flashing operation to add file system defined for this build target.")
 
     if("safeboot" not in firmware_name):
-        #print('Using esptool.py arguments: %s' % ' '.join(cmd))
         try:
-            #esptool.main(cmd)
-            output = subprocess.DEVNULL(esptool.main(cmd), shell=False)
+            print('Using esptool.py arguments: %s' % ' '.join(cmd))
+            esptool.main(cmd)
         except:
             print()
             print()

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -126,11 +126,21 @@ def patch_partitions_bin(size_string):
         print("New partition hash:",result.digest().hex())
 
 def esp32_create_chip_string(chip):
-    tasmota_platform = env.subst("$BUILD_DIR").split(os.path.sep)[-1]
-    tasmota_platform = tasmota_platform.split('-')[0]
-    if 'tasmota' + chip[3:] not in tasmota_platform: # quick check for a valid name like 'tasmota' + '32c3'
-        print('Unexpected naming conventions in this build environment -> Undefined behavior for further build process!!')
+    tasmota_platform_org = env.subst("$BUILD_DIR").split(os.path.sep)[-1]
+    tasmota_platform = tasmota_platform_org.split('-')[0]
+    if "tasmota" + chip[3:] not in tasmota_platform: # quick check for a valid name like 'tasmota' + '32c3'
+        print("Unexpected naming conventions in this build environment: ", tasmota_platform_org)
         print("Expected build environment name like 'tasmota32-whatever-you-want'")
+        print("Please correct your actual used environment, to avoid undefined behavior!!")
+    if "-DUSE_USB_CDC_CONSOLE" in env.BoardConfig().get("build.extra_flags") and "cdc" not in tasmota_platform:
+        tasmota_platform += "cdc"
+        print("WARNING: board definition uses CDC configuration, but environment name does not -> adding 'cdc' to environment name")
+        print("Please correct your actual used environment, to avoid undefined behavior!!")
+    if "solo1" in tasmota_platform_org and "tasmota32solo1" not in tasmota_platform_org:
+        print("Unexpected naming convention in this environment: ", tasmota_platform_org, " -> Undefined behavior for further build process!!")
+        print("Expected build environment name like 'tasmota32solo1-whatever-you-want'")
+        print("WARNING: Changing environment name to:", tasmota_platform)
+
     return tasmota_platform
 
 def esp32_build_filesystem(fs_size):
@@ -221,10 +231,6 @@ def esp32_create_combined_bin(source, target, env):
     new_file_name = env.subst("$BUILD_DIR/${PROGNAME}.factory.bin")
     firmware_name = env.subst("$BUILD_DIR/${PROGNAME}.bin")
     tasmota_platform = esp32_create_chip_string(chip)
-
-    if "-DUSE_USB_CDC_CONSOLE" in env.BoardConfig().get("build.extra_flags") and "cdc" not in tasmota_platform:
-        tasmota_platform += "cdc"
-        print("WARNING: board definition uses CDC configuration, but environment name does not -> changing tasmota safeboot binary to:", tasmota_platform + "-safeboot.bin")
 
     if not os.path.exists(variants_dir):
         os.makedirs(variants_dir)

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -304,10 +304,10 @@ def esp32_create_combined_bin(source, target, env):
             #output = subprocess.run(esptoolpy_cmd, capture_output=True).stdout.splitlines()
             output = subprocess.run(esptool.main(cmd), capture_output=True).stdout.splitlines()
         except:
-            print("")
-            print("")
-            print("\u001b[31;1m************ Generating the Tasmota factory image failed *************")
-            print("*   Probably unusual naming convention in this build environment     *")
-            print("* Expected build environment name like 'tasmota32-whatever-you-want' *\u001b[31;1m")
+            print()
+            print()
+            print("\033[31m************ Generating the Tasmota factory image failed *************")
+            print("\033[31m*   Probably unusual naming convention in this build environment     *")
+            print("\033[31m* Expected build environment name like 'tasmota32-whatever-you-want' *\033[0m")
 
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", esp32_create_combined_bin)

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -300,7 +300,9 @@ def esp32_create_combined_bin(source, target, env):
     if("safeboot" not in firmware_name):
         #print('Using esptool.py arguments: %s' % ' '.join(cmd))
         try:
-            esptool.main(cmd)
+            #esptool.main(cmd)
+            #output = subprocess.run(esptoolpy_cmd, capture_output=True).stdout.splitlines()
+            subprocess.call(esptool.main(cmd), shell=False)
         except:
             print("")
             print("")


### PR DESCRIPTION
## Description:

and inform user about wrong naming convention.
Provide auto fix for wrong env naming when compiling "solo1" and missing "CDC"

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
