### PR TITLE
Fix max GPIO and flash / red pins

### DIFF
--- a/tasmota/include/tasmota_template.h
+++ b/tasmota/include/tasmota_template.h
@@ -1426,13 +1426,13 @@ const char PINS_WEMOS[] PROGMEM = "AOAOAOAOAOAOIOIOIOIOIOFLFLFLFLFLFLFLIOIORXTX"
 /* ****************************************
  * ESP32C5
  * ****************************************/
-#define MAX_GPIO_PIN       27   // Number of supported GPIO
-#define MIN_FLASH_PINS     0    // Number of flash chip pins unusable for configuration (GPIO24 to 26)
-#define MAX_USER_PINS      27   // MAX_GPIO_PIN - MIN_FLASH_PINS
+#define MAX_GPIO_PIN       29   // Number of supported GPIO
+#define MIN_FLASH_PINS     0    // Number of flash chip pins unusable for configuration (GPIO16-22 SPI0/1)
+#define MAX_USER_PINS      29   // MAX_GPIO_PIN - MIN_FLASH_PINS
 #define WEMOS_MODULE       0    // Wemos module
 
-//                                  0 1 2 3 4 5 6 7 8 91011121314151617181920212223242526
-const char PINS_WEMOS[] PROGMEM = "IOAOAOAOAOAOAOIOIOIOIOIOIOIOIOIOIOIOFLFLFLIOFLFLFLIOIO";
+//                                  0 1 2 3 4 5 6 7 8 91011121314151617181920212223242526272829
+const char PINS_WEMOS[] PROGMEM = "IOAOAOAOAOAOAOIOIOIOIOIOIOIOFLFLFLFLFLFLFLIOIOIOIOIOIOIOIOIO";
 
 #elif CONFIG_IDF_TARGET_ESP32C6
 

--- a/tasmota/include/tasmota_types.h
+++ b/tasmota/include/tasmota_types.h
@@ -662,26 +662,26 @@ typedef struct {
   // -----------------------------------------------------------------------
   // Mapping 0x3AC to 0x496 for ESP32, ESP32C2, ESP32C3, ESP32C5 and ESP32C6
   // -----------------------------------------------------------------------
-  myio          my_gp;                     // 3AC  2x40 bytes (ESP32) / 2x21 bytes (ESP32-C2) / 2x22 bytes (ESP32-C3) / 2x27 bytes (ESP32-C5) / 2x31 bytes (ESP32-C6)
+  myio          my_gp;                     // 3AC  2x40 bytes (ESP32) / 2x21 bytes (ESP32-C2) / 2x22 bytes (ESP32-C3) / 2x29 bytes (ESP32-C5) / 2x31 bytes (ESP32-C6)
 
   #if CONFIG_IDF_TARGET_ESP32C2
   uint8_t       free_esp32c2_3D6[38];      // 3D6  - Due to smaller myio
   #elif CONFIG_IDF_TARGET_ESP32C3
   uint8_t       free_esp32c3_3D8[36];      // 3D8  - Due to smaller myio
   #elif CONFIG_IDF_TARGET_ESP32C5
-  uint8_t       free_esp32c5_3E2[26];      // 3E2  - Due to smaller myio
+  uint8_t       free_esp32c5_3E4[22];      // 3E4  - Due to smaller myio
   #elif CONFIG_IDF_TARGET_ESP32C6
   uint8_t       free_esp32c6_3EA[18];      // 3EA  - Due to smaller myio
   #endif  // CONFIG_IDF_TARGET_ESP32C2/3/5/6
 
-  mytmplt       user_template;             // 3FC  2x37 bytes (ESP32) / 2x22 bytes (ESP32-C2) / 2x23 bytes (ESP32-C3) / 2x28 bytes (ESP32-C5) / 2x32 bytes (ESP32-C6)
+  mytmplt       user_template;             // 3FC  2x37 bytes (ESP32) / 2x22 bytes (ESP32-C2) / 2x23 bytes (ESP32-C3) / 2x30 bytes (ESP32-C5) / 2x32 bytes (ESP32-C6)
 
   #if CONFIG_IDF_TARGET_ESP32C2
   uint8_t       free_esp32c2_428[30];      // 428  - Due to smaller mytmplt
   #elif CONFIG_IDF_TARGET_ESP32C3
   uint8_t       free_esp32c3_42A[28];      // 42A  - Due to smaller mytmplt
   #elif CONFIG_IDF_TARGET_ESP32C5
-  uint8_t       free_esp32c5_434[18];      // 434  - Due to smaller mytmplt
+  uint8_t       free_esp32c5_438[14];      // 438  - Due to smaller mytmplt
   #elif CONFIG_IDF_TARGET_ESP32C6 
   uint8_t       free_esp32c6_43C[10];      // 43C  - Due to smaller mytmplt
   #endif  // CONFIG_IDF_TARGET_ESP32C2/3/5/6

--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -1787,7 +1787,7 @@ bool FlashPin(uint32_t pin) {
 #elif CONFIG_IDF_TARGET_ESP32C3
   return ((pin > 13) && (pin < 18));   // ESP32C3 has GPIOs 11-17 reserved for Flash, with some boards GPIOs 11 12 13 are useable
 #elif CONFIG_IDF_TARGET_ESP32C5
-  return ((pin >= 16) && (pin <= 22));  // ESP32C5: GPIOs 16-22 reserved for SPI Flash/PSRAM (SPICS0, SPICLK, SPID, SPIQ, SPIHD, SPIWP, VDD_SPI)
+  return ((pin > 15) && (pin < 23));   // ESP32C5 has GPIOs 16-22 reserved for Flash
 #elif CONFIG_IDF_TARGET_ESP32C6
   return ((pin == 24) || (pin == 25) || (pin == 27) || (pin == 29) || (pin == 30));  // ESP32C6 has GPIOs 24-30 reserved for Flash, with some boards GPIOs 26 28 are useable
 #elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
@@ -1796,7 +1796,7 @@ bool FlashPin(uint32_t pin) {
   return false;                        // ESP32P4 has no flash pins, but GPIOs 34-38 are strapping pins
 #else
   return (pin >= 28) && (pin <= 31);   // ESP32 skip 28-31
-#endif  // ESP32C2/C3/C6 and S2/S3
+#endif  // ESP32C2/C3/C5/C6 and S2/S3
 #endif  // ESP32
 }
 
@@ -1810,7 +1810,7 @@ bool RedPin(uint32_t pin) {            // Pin may be dangerous to change, displa
 #elif CONFIG_IDF_TARGET_ESP32C3
   return (11 == pin) || (12 == pin) || (13 == pin);  // ESP32C3: GPIOs 11 12 13 are usually used for Flash (mode QIO/QOUT)
 #elif CONFIG_IDF_TARGET_ESP32C5
-  return ((pin == 2) || (pin == 3) || (pin == 7) || (pin == 25) || (pin == 26) || (pin == 27) || (pin == 28));  // ESP32C5: Strapping pins (MTMS, MTDI, JTAG, Boot Mode Control, SDIO Sampling, ROM Messages, Crystal Freq)
+  return (2 == pin) || (7 == pin) || (25 == pin) || (27 == pin) || (28 == pin);  // ESP32C5: GPIO2,7,25,27,28 are strapping pins
 #elif CONFIG_IDF_TARGET_ESP32C6
   return (26 == pin) || (28 == pin);   // ESP32C6: GPIOs 26 28 are usually used for Flash (mode QIO/QOUT)
 #elif CONFIG_IDF_TARGET_ESP32S2


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ ] The pull request is done against the latest development branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.3.250808
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - ESP32‑C5: Two additional GPIOs are now available for user configuration (expanded WeMos pin mapping).
- Bug Fixes
  - ESP32‑C5: Corrected flash-pin range handling to prevent unintended blocking of valid pins.
  - ESP32‑C5: Updated “red pin” safety list to remove overly restrictive pins for safer, more accurate guidance.
- Refactor
  - ESP32‑C5: Memory layout and offsets adjusted to align with expanded pin/template data, preserving settings compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->