### PR TITLE
fix ROM SHA routine use

### DIFF
--- a/lib/lib_ssl/bearssl-esp8266/src/bssl_hal_select.h
+++ b/lib/lib_ssl/bearssl-esp8266/src/bssl_hal_select.h
@@ -1,0 +1,87 @@
+/*
+ * bssl_hal_select.h — central selector for BearSSL HW HAL vs SW
+ *
+ * When -DUSE_SHA_ROM is active on an ESP32 family target, the files
+ *   src/hash/_sha_hal_idf5x.c
+ *   src/ec/_ec_c25519_m15.c
+ *   src/ec/_ec_p256_m15.c
+ * provide hardware-accelerated implementations of the same public
+ * symbols (br_sha*_init / _update / _out / _state / _set_state / _vtable
+ * and br_ec_*_m15). Without a coordinating guard, the portable software
+ * TUs (sha1.c, sha2small.c, sha2big.c, ec_p256_m15.c, ec_c25519_m15.c)
+ * emit the same symbols, producing either a "multiple definition" link
+ * failure or — when the static archive resolver picks members in an
+ * unspecified order — a half-SW/half-HAL Frankenstein chain whose
+ * midstate byte layout is inconsistent. The latter manifests as broken
+ * SHA/HMAC/ECDHE results during the TLS handshake (bad MAC, bad
+ * finished, bad certificate signature).
+ *
+ * This header defines a small set of macros that exactly mirror the
+ * conditions under which the HAL TUs emit symbols. The portable SW
+ * TUs include this header (transitively via t_inner.h) and skip the
+ * conflicting definitions when the matching macro is defined.
+ *
+ * We require the HAL to cover an *entire* algorithm family (SHA-1,
+ * SHA-224+SHA-256, SHA-384+SHA-512) before letting it take over,
+ * because mixing SW state with HAL update functions inside one family
+ * gives incompatible midstate encodings (SW stores host-order u32
+ * words → BE on save, HAL stores LE-encoded byte image). Chips that
+ * have only partial HW coverage of a family cannot currently use
+ * USE_SHA_ROM for that family; the build fails with a clear message
+ * so the user knows to disable the option.
+ */
+#ifndef BSSL_HAL_SELECT_H__
+#define BSSL_HAL_SELECT_H__
+
+#if defined(USE_SHA_ROM) && defined(ESP_PLATFORM) && !defined(ESP8266)
+
+# if __has_include("soc/sha_caps.h")
+#  include "soc/sha_caps.h"
+# elif __has_include("soc/soc_caps.h")
+#  include "soc/soc_caps.h"
+# else
+#  error "USE_SHA_ROM: cannot find soc/sha_caps.h or soc/soc_caps.h"
+# endif
+
+/* ---------- SHA family selection ---------- */
+
+/* The SHA HAL only emits anything if the IDF reports resumeable SHA. */
+# if defined(SOC_SHA_SUPPORT_RESUME) && SOC_SHA_SUPPORT_RESUME
+
+#  if defined(SOC_SHA_SUPPORT_SHA1) && SOC_SHA_SUPPORT_SHA1
+#   define BR_HAL_PROVIDES_SHA1 1
+#  endif
+
+/* SHA-224 + SHA-256 form one inseparable family in BearSSL: the SHA-256
+ * vtable references br_sha224_update / _state / _set_state. Require
+ * both to be HW-supported before letting HAL own the family. */
+#  if defined(SOC_SHA_SUPPORT_SHA256) && SOC_SHA_SUPPORT_SHA256
+#   if !defined(SOC_SHA_SUPPORT_SHA224) || !SOC_SHA_SUPPORT_SHA224
+#    error "USE_SHA_ROM: this chip has HW SHA-256 but no HW SHA-224; mixing SW SHA-224 with HAL SHA-256 corrupts the midstate. Disable -DUSE_SHA_ROM."
+#   endif
+#   define BR_HAL_PROVIDES_SHA256_FAMILY 1
+#  endif
+
+/* SHA-384 + SHA-512 likewise: SHA-512 vtable reuses br_sha384_update.
+ * Require both before letting HAL own the family. */
+#  if defined(SOC_SHA_SUPPORT_SHA512) && SOC_SHA_SUPPORT_SHA512
+#   if !defined(SOC_SHA_SUPPORT_SHA384) || !SOC_SHA_SUPPORT_SHA384
+#    error "USE_SHA_ROM: this chip has HW SHA-512 but no HW SHA-384; mixing SW SHA-384 with HAL SHA-512 corrupts the midstate. Disable -DUSE_SHA_ROM."
+#   endif
+#   define BR_HAL_PROVIDES_SHA512_FAMILY 1
+#  endif
+
+# endif /* SOC_SHA_SUPPORT_RESUME */
+
+/* ---------- EC family selection ---------- */
+
+/* The ROM bigint EC HAL TUs always emit br_ec_p256_m15 and
+ * br_ec_c25519_m15 if the chip has an MPI accelerator. */
+# if defined(SOC_MPI_SUPPORTED) && SOC_MPI_SUPPORTED
+#  define BR_HAL_PROVIDES_EC_C25519 1
+#  define BR_HAL_PROVIDES_EC_P256   1
+# endif
+
+#endif /* USE_SHA_ROM && ESP_PLATFORM && !ESP8266 */
+
+#endif /* BSSL_HAL_SELECT_H__ */

--- a/lib/lib_ssl/bearssl-esp8266/src/ec/_ec_c25519_m15.c
+++ b/lib/lib_ssl/bearssl-esp8266/src/ec/_ec_c25519_m15.c
@@ -36,6 +36,16 @@
 #include "rom/bigint.h"
 #include "t_inner.h"
 
+/* Shared MPI lock — see _ec_p256_m15.c for rationale. */
+#if __has_include("esp_crypto_lock.h")
+# include "esp_crypto_lock.h"
+# define BR_MPI_LOCK_ACQUIRE() esp_crypto_mpi_lock_acquire()
+# define BR_MPI_LOCK_RELEASE() esp_crypto_mpi_lock_release()
+#else
+# define BR_MPI_LOCK_ACQUIRE() ((void)0)
+# define BR_MPI_LOCK_RELEASE() ((void)0)
+#endif
+
 #define WORDS 8  /* 8×32-bit limbs */
 
 /* 
@@ -267,6 +277,7 @@ api_mul(unsigned char *G, size_t Glen,
     uint32_t a[WORDS], aa[WORDS], b[WORDS], bb[WORDS];
     uint32_t c[WORDS], d[WORDS], e[WORDS], da[WORDS], cb[WORDS];
     uint32_t t[WORDS];
+    BR_MPI_LOCK_ACQUIRE();
 #if defined(CONFIG_IDF_TARGET_ESP32)
     ets_bigint_enable();
 #endif
@@ -316,6 +327,7 @@ api_mul(unsigned char *G, size_t Glen,
 #if defined(CONFIG_IDF_TARGET_ESP32)
     ets_bigint_disable();
 #endif
+    BR_MPI_LOCK_RELEASE();
 
     /* Final reduction if needed and serialize */
     if (ge_ct(unorm, P_LE)) {

--- a/lib/lib_ssl/bearssl-esp8266/src/ec/_ec_p256_m15.c
+++ b/lib/lib_ssl/bearssl-esp8266/src/ec/_ec_p256_m15.c
@@ -37,6 +37,18 @@
 #include "rom/bigint.h"
 #include "t_inner.h"
 
+/* The MPI accelerator is shared with mbedTLS RSA, ECDSA-software-fallback
+ * and DS. Always use the IDF lock so concurrent users cannot corrupt our
+ * Montgomery multiplications during a TLS handshake. */
+#if __has_include("esp_crypto_lock.h")
+# include "esp_crypto_lock.h"
+# define BR_MPI_LOCK_ACQUIRE() esp_crypto_mpi_lock_acquire()
+# define BR_MPI_LOCK_RELEASE() esp_crypto_mpi_lock_release()
+#else
+# define BR_MPI_LOCK_ACQUIRE() ((void)0)
+# define BR_MPI_LOCK_RELEASE() ((void)0)
+#endif
+
 #define WORDS 8
 
 #if defined(CONFIG_IDF_TARGET_ESP32)
@@ -443,6 +455,7 @@ static uint32_t api_mul(unsigned char *G, size_t Glen,
     (void)curve;
     p256_pt Pp, R;
     if (!load_point_uncompressed(&Pp, G, Glen)) return 0;
+    BR_MPI_LOCK_ACQUIRE();
 #if defined(CONFIG_IDF_TARGET_ESP32)
     ets_bigint_enable();
 #endif
@@ -451,6 +464,7 @@ static uint32_t api_mul(unsigned char *G, size_t Glen,
 #if defined(CONFIG_IDF_TARGET_ESP32)
     ets_bigint_disable();
 #endif
+    BR_MPI_LOCK_RELEASE();
     store_point_uncompressed(G, &R);
     return 1;
 }
@@ -461,6 +475,7 @@ static size_t api_mulgen(unsigned char *Rbuf,
     (void)curve;
     p256_pt Gp, R;
     load_generator(&Gp);
+    BR_MPI_LOCK_ACQUIRE();
 #if defined(CONFIG_IDF_TARGET_ESP32)
     ets_bigint_enable();
 #endif
@@ -471,6 +486,7 @@ static size_t api_mulgen(unsigned char *Rbuf,
 #if defined(CONFIG_IDF_TARGET_ESP32)
     ets_bigint_disable();
 #endif
+    BR_MPI_LOCK_RELEASE();
 
     store_point_uncompressed(Rbuf, &R);
     return 65;
@@ -493,6 +509,7 @@ static uint32_t api_muladd(unsigned char *A, const unsigned char *B,
         load_generator(&Qp);
     }
 
+    BR_MPI_LOCK_ACQUIRE();
 #if defined(CONFIG_IDF_TARGET_ESP32)
     ets_bigint_enable();
 #endif
@@ -505,6 +522,7 @@ static uint32_t api_muladd(unsigned char *A, const unsigned char *B,
 #if defined(CONFIG_IDF_TARGET_ESP32)
     ets_bigint_disable();
 #endif
+    BR_MPI_LOCK_RELEASE();
 
     store_point_uncompressed(A, &R);
     return 1;

--- a/lib/lib_ssl/bearssl-esp8266/src/ec/ec_c25519_m15.c
+++ b/lib/lib_ssl/bearssl-esp8266/src/ec/ec_c25519_m15.c
@@ -24,6 +24,11 @@
 
 #include "t_inner.h"
 
+/* The HW HAL (_ec_c25519_m15.c) owns br_ec_c25519_m15 when USE_SHA_ROM
+ * is active and the chip has an MPI accelerator. Skip the entire SW
+ * implementation in that case. */
+#ifndef BR_HAL_PROVIDES_EC_C25519
+
 /* obsolete
 #include <stdio.h>
 #include <stdlib.h>
@@ -1476,3 +1481,4 @@ const br_ec_impl br_ec_c25519_m15 PROGMEM = {
 	&api_mulgen,
 	&api_muladd
 };
+#endif /* !BR_HAL_PROVIDES_EC_C25519 */

--- a/lib/lib_ssl/bearssl-esp8266/src/ec/ec_p256_m15.c
+++ b/lib/lib_ssl/bearssl-esp8266/src/ec/ec_p256_m15.c
@@ -24,6 +24,11 @@
 
 #include "t_inner.h"
 
+/* The HW HAL (_ec_p256_m15.c) owns br_ec_p256_m15 when USE_SHA_ROM
+ * is active and the chip has an MPI accelerator. Skip the entire SW
+ * implementation in that case. */
+#ifndef BR_HAL_PROVIDES_EC_P256
+
 /*
  * If BR_NO_ARITH_SHIFT is undefined, or defined to 0, then we _assume_
  * that right-shifting a signed negative integer copies the sign bit
@@ -2109,3 +2114,5 @@ const br_ec_impl br_ec_p256_m15 PROGMEM = {
 	&api_mulgen,
 	&api_muladd
 };
+
+#endif /* !BR_HAL_PROVIDES_EC_P256 */

--- a/lib/lib_ssl/bearssl-esp8266/src/hash/_sha_hal_idf5x.c
+++ b/lib/lib_ssl/bearssl-esp8266/src/hash/_sha_hal_idf5x.c
@@ -53,10 +53,55 @@
 #define HAVE_HAL_SHA384  (SOC_SHA_SUPPORT_SHA384)
 #define HAVE_HAL_SHA512  (SOC_SHA_SUPPORT_SHA512)
 
+/* ------------------------------------------------------------------
+ * Lock sharing with ESP-IDF mbedTLS / WPA / OTA.
+ *
+ * The SHA accelerator is a single shared peripheral. ESP-IDF's own
+ * mbedTLS, Wi-Fi WPA2 EAPOL and OTA verification all reach it via the
+ * lock published in esp_crypto_lock.h. A private portMUX here would
+ * not serialize against those users — a TLS handshake concurrent with
+ * a Wi-Fi key derivation would corrupt the midstate.
+ *
+ * Use the IDF lock when esp_crypto_lock.h is available (IDF 5.x for
+ * every ESP32 family that has a SHA accelerator) and fall back to a
+ * private spinlock only when the header is not present.
+ * ------------------------------------------------------------------ */
+#if __has_include("esp_crypto_lock.h")
+# include "esp_crypto_lock.h"
+# define BR_SHA_USE_IDF_LOCK 1
+#endif
+
+#if BR_SHA_USE_IDF_LOCK
+/* The IDF SHA lock also covers AES (shared crypto-DMA on S2/S3). Still
+ * call sha_ll_enable_bus_clock/reset_register here because the IDF lock
+ * does not by itself touch the bus clock; mbedTLS does it inside its
+ * own per-call wrapper. */
+# define SHA_ENTER()  do { esp_crypto_sha_aes_lock_acquire(); \
+                           { int __DECLARE_RCC_ATOMIC_ENV; \
+                             sha_ll_enable_bus_clock(true); \
+                             sha_ll_reset_register(); } } while (0)
+# define SHA_EXIT()   do { { int __DECLARE_RCC_ATOMIC_ENV; \
+                             sha_ll_enable_bus_clock(false); } \
+                           esp_crypto_sha_aes_lock_release(); } while (0)
+#else
 static portMUX_TYPE s_sha_mux = portMUX_INITIALIZER_UNLOCKED;
-#define SHA_ENTER()  {portENTER_CRITICAL(&s_sha_mux); int __DECLARE_RCC_ATOMIC_ENV; sha_ll_enable_bus_clock(true); sha_ll_reset_register();}
-#define SHA_EXIT()   {portEXIT_CRITICAL(&s_sha_mux); int __DECLARE_RCC_ATOMIC_ENV; sha_ll_enable_bus_clock(false);}
+# define SHA_ENTER()  {portENTER_CRITICAL(&s_sha_mux); int __DECLARE_RCC_ATOMIC_ENV; sha_ll_enable_bus_clock(true); sha_ll_reset_register();}
+# define SHA_EXIT()   {portEXIT_CRITICAL(&s_sha_mux); int __DECLARE_RCC_ATOMIC_ENV; sha_ll_enable_bus_clock(false);}
+#endif
+
 #define SHA_WAIT()   {while (sha_ll_busy()) { } }
+
+/* On ESP32-P4 with IDF >= 5.5 the SHA mode register must be programmed
+ * explicitly via sha_ll_set_mode() before every operation; the bare
+ * mode argument to sha_ll_load() / start_block() / continue_block() is
+ * no longer sufficient. This macro is a no-op on every other target. */
+#if defined(CONFIG_IDF_TARGET_ESP32P4) && defined(ESP_IDF_VERSION) && \
+    defined(ESP_IDF_VERSION_VAL) && \
+    ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
+# define SHA_SET_MODE(m) sha_ll_set_mode(m)
+#else
+# define SHA_SET_MODE(m) ((void)0)
+#endif
 
 /* ================================================================
  * SHA-1 (HAL path, no save/restore) - needs char buf[112];
@@ -69,9 +114,7 @@ sha_hal_process_block(void *state_buf, const void *blk,
                       size_t block_words, bool first)
 {
     SHA_ENTER();
-#if defined(CONFIG_IDF_TARGET_ESP32P4) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
-    sha_ll_set_mode(type); // required on P4 in IDF 5.5+
-#endif 
+    SHA_SET_MODE(type);
     if (!first) {
         sha_ll_write_digest(type, state_buf, digest_words);
     }
@@ -306,6 +349,7 @@ void br_sha224_update(br_sha224_context *cc, const void *data, size_t len)
         size_t block_count_in_run = 0;
 
         SHA_ENTER();
+        SHA_SET_MODE(mode);
 
         /* Complete the partial block (stitch) if needed */
         if (stitch_take) {
@@ -409,6 +453,7 @@ void br_sha256_out(const br_sha256_context *cc, void *out)
     bool must_start_from_iv = midstate_is_iv && no_full_blocks_done;
 
     SHA_ENTER();
+    SHA_SET_MODE(mode);
 
     if (!must_start_from_iv) {
         uint32_t midstate_words[8];
@@ -545,7 +590,7 @@ void br_sha384_update(br_sha384_context *cc, const void *data, size_t len) {
             br_range_dec64le(st_be, 8, cc->val);
             br_range_enc64be(st_be, st_be, 8);
             SHA_ENTER();
-            sha_ll_load(SHA2_512);
+            SHA_SET_MODE(SHA2_512); sha_ll_load(SHA2_512);
             sha_ll_write_digest(SHA2_512, st_be, 16);
             sha_ll_fill_text_block(cc->buf, 32);
             sha_ll_continue_block(SHA2_512);
@@ -565,7 +610,7 @@ void br_sha384_update(br_sha384_context *cc, const void *data, size_t len) {
         br_range_enc64be(st_be, st_be, 8);
         bool first = (prior_count == 0);
         SHA_ENTER();
-        sha_ll_load(SHA2_512);
+        SHA_SET_MODE(SHA2_512); sha_ll_load(SHA2_512);
         sha_ll_write_digest(SHA2_512, st_be, 16);
         while (len >= 128) {
             sha_ll_fill_text_block(src, 32);
@@ -601,7 +646,7 @@ void br_sha384_out(const br_sha384_context *cc, void *out) {
         br_range_dec64le(st_be, 8, ctx.val);
         br_range_enc64be(st_be, st_be, 8);
         SHA_ENTER();
-        sha_ll_load(SHA2_512);
+        SHA_SET_MODE(SHA2_512); sha_ll_load(SHA2_512);
         sha_ll_write_digest(SHA2_512, st_be, 16);
         sha_ll_fill_text_block(ctx.buf, 32);
         sha_ll_continue_block(SHA2_512);
@@ -621,7 +666,7 @@ void br_sha384_out(const br_sha384_context *cc, void *out) {
     br_range_dec64le(st_be2, 8, ctx.val);
     br_range_enc64be(st_be2, st_be2, 8);
     SHA_ENTER();
-    sha_ll_load(SHA2_512);
+    SHA_SET_MODE(SHA2_512); sha_ll_load(SHA2_512);
     sha_ll_write_digest(SHA2_512, st_be2, 16);
     sha_ll_fill_text_block(ctx.buf, 32);
     sha_ll_continue_block(SHA2_512);
@@ -701,7 +746,7 @@ void br_sha512_out(const br_sha512_context *cc, void *out) {
         br_range_dec64le(st_be, 8, ctx.val);
         br_range_enc64be(st_be, st_be, 8);
         SHA_ENTER();
-        sha_ll_load(SHA2_512);
+        SHA_SET_MODE(SHA2_512); sha_ll_load(SHA2_512);
         sha_ll_write_digest(SHA2_512, st_be, 16);
         sha_ll_fill_text_block(ctx.buf, 32);
         sha_ll_continue_block(SHA2_512);
@@ -721,7 +766,7 @@ void br_sha512_out(const br_sha512_context *cc, void *out) {
     br_range_dec64le(st_be2, 8, ctx.val);
     br_range_enc64be(st_be2, st_be2, 8);
     SHA_ENTER();
-    sha_ll_load(SHA2_512);
+    SHA_SET_MODE(SHA2_512); sha_ll_load(SHA2_512);
     sha_ll_write_digest(SHA2_512, st_be2, 16);
     sha_ll_fill_text_block(ctx.buf, 32);
     sha_ll_continue_block(SHA2_512);

--- a/lib/lib_ssl/bearssl-esp8266/src/hash/sha1.c
+++ b/lib/lib_ssl/bearssl-esp8266/src/hash/sha1.c
@@ -41,6 +41,12 @@ const uint32_t br_sha1_IV[5] PROGMEM = {
 	0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0
 };
 
+/* The HW HAL (_sha_hal_idf5x.c) emits br_sha1_init / _update / _out /
+ * _state / _set_state and br_sha1_vtable when USE_SHA_ROM selects it.
+ * Skip the conflicting SW definitions in that case; br_sha1_IV is still
+ * needed by md5sha1.c so it remains defined above. */
+#ifndef BR_HAL_PROVIDES_SHA1
+
 /* see inner.h */
 void
 br_sha1_round(const unsigned char *buf, uint32_t *val)
@@ -189,3 +195,5 @@ const br_hash_class br_sha1_vtable PROGMEM = {
 	(void (*)(const br_hash_class **, const void *, uint64_t))
 		&br_sha1_set_state
 };
+
+#endif /* !BR_HAL_PROVIDES_SHA1 */

--- a/lib/lib_ssl/bearssl-esp8266/src/hash/sha2big.c
+++ b/lib/lib_ssl/bearssl-esp8266/src/hash/sha2big.c
@@ -24,6 +24,11 @@
 
 #include "t_inner.h"
 
+/* The HW HAL (_sha_hal_idf5x.c) owns the entire SHA-384 + SHA-512 family
+ * when USE_SHA_ROM is active on an ESP32 with a fully supported HW SHA
+ * engine. Skip every symbol here in that case (see sha2small.c). */
+#ifndef BR_HAL_PROVIDES_SHA512_FAMILY
+
 #define CH(X, Y, Z)    ((((Y) ^ (Z)) & (X)) ^ (Z))
 #define MAJ(X, Y, Z)   (((Y) & (Z)) | (((Y) | (Z)) & (X)))
 
@@ -283,3 +288,5 @@ const br_hash_class br_sha512_vtable PROGMEM = {
 	(void (*)(const br_hash_class **, const void *, uint64_t))
 		&br_sha512_set_state
 };
+
+#endif /* !BR_HAL_PROVIDES_SHA512_FAMILY */

--- a/lib/lib_ssl/bearssl-esp8266/src/hash/sha2small.c
+++ b/lib/lib_ssl/bearssl-esp8266/src/hash/sha2small.c
@@ -24,6 +24,14 @@
 
 #include "t_inner.h"
 
+/* The HW HAL (_sha_hal_idf5x.c) owns the entire SHA-224 + SHA-256 family
+ * when USE_SHA_ROM is active on an ESP32 with a fully supported HW SHA
+ * engine. Skip every symbol defined here in that case to avoid duplicate
+ * definitions and incompatible midstate byte layouts.
+ * br_sha224_IV / br_sha256_IV / br_sha2small_round are only consumed
+ * inside this TU, so dropping them is safe. */
+#ifndef BR_HAL_PROVIDES_SHA256_FAMILY
+
 #define CH(X, Y, Z)    ((((Y) ^ (Z)) & (X)) ^ (Z))
 #define MAJ(X, Y, Z)   (((Y) & (Z)) | (((Y) | (Z)) & (X)))
 
@@ -339,3 +347,5 @@ const br_hash_class br_sha256_vtable PROGMEM = {
 	(void (*)(const br_hash_class **, const void *, uint64_t))
 		&br_sha256_set_state
 };
+
+#endif /* !BR_HAL_PROVIDES_SHA256_FAMILY */

--- a/lib/lib_ssl/bearssl-esp8266/src/t_inner.h
+++ b/lib/lib_ssl/bearssl-esp8266/src/t_inner.h
@@ -34,6 +34,10 @@
 #include "t_config.h"
 #include "t_bearssl.h"
 
+/* Decide whether HW HAL or SW implementations own SHA / EC symbols.
+ * Must be included before any SW TU emits br_sha* / br_ec_* symbols. */
+#include "bssl_hal_select.h"
+
 /*
  * On MSVC, disable the warning about applying unary minus on an
  * unsigned type: it is standard, we do it all the time, and for

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -30,8 +30,10 @@ build_flags                 = ${esp_defaults.build_flags}
                               -Dsint16_t=int16_t
                               -Dmemcpy_P=memcpy
                               -Dmemcmp_P=memcmp
-                              ; disable ROM routines, use causes issues with TLS
-                              ;-DUSE_SHA_ROM
+                              ; HW SHA/MPI HAL: requires a chip with full HW
+                              ; coverage of the SHA-224/256 (and SHA-384/512)
+                              ; families. Disable for ESP32 classic / ESP32-S2.
+                              -DUSE_SHA_ROM
                               ;for TLS we can afford compiling for 4K RSA keys
                               -DUSE_4K_RSA
                               -I$PROJECT_DIR/include


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ ] The pull request is done against the latest development branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved conflicts between hardware and software SSL/TLS cryptographic implementations on ESP32 platforms.
  * Added thread-safe locking to prevent hardware accelerator corruption during concurrent operations.

* **Improvements**
  * Enabled hardware SHA acceleration by default on compatible ESP32 devices for improved TLS handshake performance.
  * Enhanced hardware elliptic-curve cryptography support for P-256 and Curve25519.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jason2866/Tasmota/pull/582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->